### PR TITLE
Force "default" key for empty key string

### DIFF
--- a/models/cbcsrf.cfc
+++ b/models/cbcsrf.cfc
@@ -44,9 +44,14 @@ component accessors="true" singleton {
 	 *
 	 * @return The csrf token
 	 */
-	public string function generate( string key = "default", boolean forceNew = false ){
+	public string function generate( string key, boolean forceNew = false ){
 		// Get our session csrf data
 		var csrfData = cacheStorage.get( getTokenStorageKey(), {} );
+
+		// Mixins pass an empty key argument so "default" isn't set and verification fails when using the examples given in readme.md
+		if (!key.len()){
+			arguments.key = "default";
+		}
 
 		// Validate data
 		if (

--- a/models/cbcsrf.cfc
+++ b/models/cbcsrf.cfc
@@ -49,7 +49,7 @@ component accessors="true" singleton {
 		var csrfData = cacheStorage.get( getTokenStorageKey(), {} );
 
 		// Mixins pass an empty key argument so "default" isn't set and verification fails when using the examples given in readme.md
-		if (!key.len()){
+		if ( isNull( arguments.key ) || !arguments.key.len() ){
 			arguments.key = "default";
 		}
 


### PR DESCRIPTION
When trying the examples in the readme, I found that the mixins pass a "key" argument, but it's an empty string so "default" doesn't get set and verification fails.
