### PR TITLE
Added a new mixin - csrfField()

### DIFF
--- a/helpers/Mixins.cfm
+++ b/helpers/Mixins.cfm
@@ -42,4 +42,43 @@
 		getInstance( '@cbcsrf' ).rotate();
 		return this;
 	}
+
+	
+
+	/**
+	 * Generate a random token in a hidden form element and javascript that will refresh the page when the token becomes stale
+	 * This function sets the key =  cfid by default so it's unique per user.  It forces a new token so the expiration is reset.
+	 * If you are using this in several locations on a page it will reset the token every time it's called.  
+	 * So call it once to get the field and store that in a variable:
+	 * 
+	 * <cfset csrfField = csrfField()>
+	 * 
+	 * Then include #csrfField# in your forms.
+	 * 
+	 * Alternatively, call #csrfField()# once in the first form, then #csrf(cfid)# in the rest.
+	 * 
+	 * @key A random token is generated for the key provided. CFID is the default
+	 * @forceNew If set to true, a new token is generated every time the function is called. If false, in case a token exists for the key, the same key is returned.
+	 *
+	 * @return HTML of the hidden field (csrf)
+	 */
+	function csrfField( string key=cfid, boolean forceNew=true ){
+	
+		savecontent variable="block" {
+			writeOutput("
+			<script>
+				var check = Date.now();
+				var timeout = #getModuleSettings( 'cbcsrf' ).rotationTimeout#; // expiration is set in /config/coldbox.cfc moduleSettings.cbcsrf.rotationTimeout
+				document.addEventListener('focus',function(){
+					if (Date.now() - check >= timeout * 60000 ){ 
+						location.reload();
+					}
+				})
+			</script>");
+		}
+
+		cfhtmlhead( text=block );
+		
+		return "<input type='hidden' name='csrf' id='csrf' value='#csrfToken( argumentCollection=arguments )#'>";
+	}
 </cfscript>


### PR DESCRIPTION
I added a new mixin that mimics csrf() but uses cfid as the key, forces a new token to reset the expiration and uses cfhtmlhead to add javascript that will refresh the page once the token expires.  The most common error I get with "enableAutoVerifier : true" is invalid token because I had let a form sit just long enough for the token to expire.  This code alleviates that.

Frankly I think this should be how csrf() works by default, but created the new method for backwards compatibility.  Not stuck on the name, though - if you can think of something better, use it.