### PR TITLE
Added csrfField() mixin

### DIFF
--- a/helpers/Mixins.cfm
+++ b/helpers/Mixins.cfm
@@ -31,7 +31,40 @@
 	 *
 	 * @return HTML of the hidden field (csrf)
 	 */
-	function csrf( string key='', boolean forceNew=false ){
+	string function csrf( string key='', boolean forceNew=false ){
+		return "<input type='hidden' name='csrf' id='csrf' value='#csrfToken( argumentCollection=arguments )#'>";
+	}
+
+	/**
+	 * Generate a random token in a hidden form element and javascript that will refresh the page automatically when the token expires
+	 * 
+	 * @key A random token is generated for the key provided. CFID is the default
+	 * @forceNew If set to true, a new token is generated every time the function is called. If false, in case a token exists for the key, the same key is returned.
+	 *
+	 * @return HTML of the hidden field (csrf)
+	 */
+	string function csrfField( string key='', boolean forceNew=false ){
+		if (!event.getPrivateValue('csrfFieldGen', false)){
+			savecontent variable="block" {
+				writeOutput("
+				<script>
+					var check = Date.now();
+					var timeout = #getModuleSettings( 'cbcsrf' ).rotationTimeout#; // expiration is set in /config/coldbox.cfc moduleSettings.cbcsrf.rotationTimeout
+					document.addEventListener('focus',function(){
+						if (Date.now() - check >= timeout * 60000 ){ 
+							location.reload();
+						}
+					})
+				</script>");
+			}
+			
+			cfhtmlbody( text=block );
+
+			event.setPrivateValue('csrfFieldGen', true);
+
+			return "<input type='hidden' name='csrf' id='csrf' value='#csrfToken( arguments.key, true )#'>";
+		}
+		
 		return "<input type='hidden' name='csrf' id='csrf' value='#csrfToken( argumentCollection=arguments )#'>";
 	}
 
@@ -41,44 +74,5 @@
 	function csrfRotate(){
 		getInstance( '@cbcsrf' ).rotate();
 		return this;
-	}
-
-	
-
-	/**
-	 * Generate a random token in a hidden form element and javascript that will refresh the page when the token becomes stale
-	 * This function sets the key =  cfid by default so it's unique per user.  It forces a new token so the expiration is reset.
-	 * If you are using this in several locations on a page it will reset the token every time it's called.  
-	 * So call it once to get the field and store that in a variable:
-	 * 
-	 * <cfset csrfField = csrfField()>
-	 * 
-	 * Then include #csrfField# in your forms.
-	 * 
-	 * Alternatively, call #csrfField()# once in the first form, then #csrf(cfid)# in the rest.
-	 * 
-	 * @key A random token is generated for the key provided. CFID is the default
-	 * @forceNew If set to true, a new token is generated every time the function is called. If false, in case a token exists for the key, the same key is returned.
-	 *
-	 * @return HTML of the hidden field (csrf)
-	 */
-	function csrfField( string key=cfid, boolean forceNew=true ){
-	
-		savecontent variable="block" {
-			writeOutput("
-			<script>
-				var check = Date.now();
-				var timeout = #getModuleSettings( 'cbcsrf' ).rotationTimeout#; // expiration is set in /config/coldbox.cfc moduleSettings.cbcsrf.rotationTimeout
-				document.addEventListener('focus',function(){
-					if (Date.now() - check >= timeout * 60000 ){ 
-						location.reload();
-					}
-				})
-			</script>");
-		}
-
-		cfhtmlhead( text=block );
-		
-		return "<input type='hidden' name='csrf' id='csrf' value='#csrfToken( argumentCollection=arguments )#'>";
 	}
 </cfscript>

--- a/helpers/Mixins.cfm
+++ b/helpers/Mixins.cfm
@@ -42,4 +42,43 @@
 		getInstance( '@cbcsrf' ).rotate();
 		return this;
 	}
+
+	
+
+	/**
+	 * Generate a random token in a hidden form element and javascript that will refresh the page when the token becomes stale
+	 * This function sets the key =  cfid by default so it's unique per user.  It forces a new token so the expiration is reset.
+	 * If you are using this in several locations on a page it will reset the token every time it's called.  
+	 * So call it once to get the field and store that in a variable:
+	 * 
+	 * <cfset csrfField = csrfField()>
+	 * 
+	 * Then include #csrfField# in your forms.
+	 * 
+	 * Alternatively, call #csrfField()# once in the first form, then #csrf(cfid)# in the rest.
+	 * 
+	 * @key A random token is generated for the key provided. CFID is the default
+	 * @forceNew If set to true, a new token is generated every time the function is called. If false, in case a token exists for the key, the same key is returned.
+	 *
+	 * @return HTML of the hidden field (csrf)
+	 */
+	function csrfField( string key=cfid, boolean forceNew=true ){
+	
+		savecontent variable="block" {
+			writeOutput("
+			<script>
+				var check = Date.now();
+				var timeout = #getModuleSettings( 'cbcsrf' ).rotationTimeout#; // expiration is set in /config/coldbox.cfc moduleSettings.cbcsrf.rotationTimeout
+				document.addEventListener('focus',function(){
+					if (Date.now() - check >= timeout * 60000 ){ 
+						location.reload();
+					}
+				})
+			</script>");
+		}
+
+		cfhtmlhead( text=block );
+		
+		return "<input type='hidden' name='csrf' id='csrf' value='#csrfToken( argumentCollection=arguments )#'>";
+	}
 </cfscript>

--- a/models/cbcsrf.cfc
+++ b/models/cbcsrf.cfc
@@ -47,7 +47,7 @@ component accessors="true" singleton {
 	public string function generate( string key, boolean forceNew = false ){
 		// Get our session csrf data
 		var csrfData = cacheStorage.get( getTokenStorageKey(), {} );
-
+		
 		// Mixins pass an empty key argument so "default" isn't set and verification fails when using the examples given in readme.md
 		if ( isNull( arguments.key ) || !arguments.key.len() ){
 			arguments.key = "default";
@@ -84,9 +84,14 @@ component accessors="true" singleton {
 	 *
 	 * @return If the token validated
 	 */
-	public boolean function verify( required string token = "", string key = "default" ){
+	public boolean function verify( required string token = "", string key ){
 		var csrfData = cacheStorage.get( getTokenStorageKey(), {} );
-
+				
+		// Mixins pass an empty key argument so "default" isn't set and verification fails when using the examples given in readme.md
+		if ( isNull( arguments.key ) || !arguments.key.len() ){
+			arguments.key = "default";
+		}
+		
 		// Verify it
 		return (
 			csrfData.keyExists( arguments.key ) && // Do we have data for the key

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,7 @@ This module will add the following UDFs into any framework files:
 - `csrfToken()` : To generate a token, using the `default` or a custom key
 - `csrfVerify()` : Verify a valid token or not
 - `csrf()` : To generate a hidden field (`csrf`) with the token
+- `csrfField()` : To generate a hidden field (`csrf`) with the token, force new token generation and include javascript that will reload the page if the token expires
 - `csrfRotate()` : To wipe and rotate the tokens for the user
 
 Here are the method signatures:
@@ -104,7 +105,15 @@ boolean function csrfVerify( required string token='', string key='' )
  *
  * @return HTML of the hidden field (csrf)
  */
-function csrf( string key='', boolean forceNew=false )
+string function csrf( string key='', boolean forceNew=false )
+/**
+ * Generate a random token in a hidden form element and javascript that will refresh the page automatically when the token expires
+ * @key A random token is generated for the key provided. CFID is the default
+ * @forceNew If set to true, a new token is generated every time the function is called. If false, in case a token exists for the key, the same key is returned.
+ *
+ * @return HTML of the hidden field (csrf)
+ */
+string function csrfField( string key='', boolean forceNew=false )
 /**
  * Clears out all csrf token stored
  */


### PR DESCRIPTION
I got tired of getting invalid token exceptions because I loaded a page with a token that was about to expire or let the form sit too long before submitting.  This mixin mimics csrf() but forces a new token and adds a block of javascript to the document, synchronized with the rotateTimeout setting, that will reload the page if the token expires.

You can call this mixin multiple times in the same request and it will only generate the javascript and new token on the first call.