### PR TITLE
ensure actionMarkedToSkip returns a boolean

### DIFF
--- a/interceptors/VerifyCsrf.cfc
+++ b/interceptors/VerifyCsrf.cfc
@@ -103,7 +103,7 @@ component extends="coldbox.system.Interceptor" accessors="true" {
     private boolean function actionMarkedToSkip( required event ) {
 		var handlerBean = handlerService.getHandlerBean( arguments.event.getCurrentEvent() );
 		if ( handlerBean.getHandler() == "" ) {
-			return;
+			return false;
 		}
 
 		// If metadata is not loaded, load it


### PR DESCRIPTION
Fix VerifyCSRF actionMarkedToSkip for views without handlers to actually return a boolean. Returning an empty string errors.
If the handler is implicit, it would error currently.