### PR TITLE
Add CacheStorage override setting

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -38,7 +38,9 @@ component {
 			// If you do not want expiring tokens, then set this value to 0
 			rotationTimeout : 30,
 			// Enable the /cbcsrf/generate endpoint to generate cbcsrf tokens for secured users.
-			enableEndpoint : false
+			enableEndpoint : false,
+			// The WireBox mapping to use for the CacheStorage
+			cacheStorage = "CacheStorage@cbstorages"
 		};
 
 		// Generate token key for users
@@ -49,6 +51,7 @@ component {
 	 * Fires upon load
 	 */
 	function onLoad(){
+		binder.map( "CacheStorage@cbcsrf" ).toDSL( settings.cacheStorage );
 		// Auto load verifier?
 		if( settings.enableAutoVerifier ){
 			controller.getInterceptorService()

--- a/models/cbcsrf.cfc
+++ b/models/cbcsrf.cfc
@@ -11,7 +11,7 @@ component accessors="true" singleton {
 	 ********************************************************************* */
 
 	property name="settings" inject="coldbox:moduleSettings:cbcsrf";
-	property name="cacheStorage" inject="cacheStorage@cbstorages";
+	property name="cacheStorage" inject="cacheStorage@cbcsrf";
 
 	/* *********************************************************************
 	 **						Properties

--- a/readme.md
+++ b/readme.md
@@ -59,12 +59,14 @@ moduleSettings = {
 		// If you do not want expiring tokens, then set this value to 0
 		rotationTimeout : 30,
 		// Enable the /cbcsrf/generate endpoint to generate cbcsrf tokens for secured users.
-		enableEndpoint : false
+		enableEndpoint : false,
+		// The WireBox mapping to use for the CacheStorage
+		cacheStorage = "CacheStorage@cbstorages"
 	}
 };
 ```
 
-This module also relies on the cbstorages module which also requires a structure in moduleSettings.  Find the updated documentation here: https://github.com/coldbox-modules/cbstorages#settings
+This module also relies on the cbstorages module which also requires a structure in `moduleSettings`.  Find the updated documentation here: https://github.com/coldbox-modules/cbstorages#settings
 
 ## Mixins
 

--- a/test-harness/tests/specs/csrfSpec.cfc
+++ b/test-harness/tests/specs/csrfSpec.cfc
@@ -9,7 +9,7 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root"{
 
 			beforeEach(function( currentSpec ){
 				csrf = getInstance( "@cbcsrf" );
-				cacheStorage = getInstance( "cacheStorage@cbstorages" );
+				cacheStorage = getInstance( "cacheStorage@cbcsrf" );
 				csrf.rotate();
 				setup();
 			});


### PR DESCRIPTION
This lets users provide whatever storage they want as long as it implements [`IStorage` from cbstorages.](https://github.com/coldbox-modules/cbstorages/blob/development/models/IStorage.cfc)