### PR TITLE
Whitelist cbdebugger

### DIFF
--- a/interceptors/VerifyCsrf.cfc
+++ b/interceptors/VerifyCsrf.cfc
@@ -55,16 +55,7 @@ component extends="coldbox.system.Interceptor" accessors="true" {
 		}
 
 		// is the incoming event is in the skipped events?
-		if (
-			variables.cbcsrf
-				.getSettings()
-				.verifyExcludes
-				.filter( function( item ){
-					// If found, then don't return it
-					return !reFindNoCase( item, event.getCurrentEvent() );
-				} )
-				.len() != variables.cbcsrf.getSettings().verifyExcludes.len()
-		) {
+		if ( actionFlaggedToSkip( arguments.event ) ) {
 			if ( log.canDebug() ) {
 				log.debug(
 					"cbcsrf Verify skipped as event: #event.getCurrentEvent()# is in the verify excludes list."
@@ -99,11 +90,27 @@ component extends="coldbox.system.Interceptor" accessors="true" {
 		}
 	}
 
+
+	/**
+	 * Are we skipping the action or not due to the verifyExcludes setting?
+	 *
+	 * @event
+	 */
+	private boolean function actionFlaggedToSkip( required event ){
+		var actionsToExcludes = [ "^cbdebugger:" ];
+		actionsToExcludes.append( variables.cbcsrf.getSettings().verifyExcludes, true );
+		return actionsToExcludes
+			.filter( function( item ){
+				// If found, then don't return it
+				return !reFindNoCase( item, event.getCurrentEvent() );
+			} )
+			.len() != actionsToExcludes.len();
+	}
+
 	/**
 	 * Are we skipping the action or not due to the skipCsrf annotation?
 	 *
-	 * @event        
-	 * @interceptData
+	 * @event
 	 */
 	private boolean function actionMarkedToSkip( required event ){
 		var handlerBean = handlerService.getHandlerBean( arguments.event.getCurrentEvent() );

--- a/interceptors/VerifyCsrf.cfc
+++ b/interceptors/VerifyCsrf.cfc
@@ -100,11 +100,9 @@ component extends="coldbox.system.Interceptor" accessors="true" {
 		var actionsToExcludes = [ "^cbdebugger:" ];
 		actionsToExcludes.append( variables.cbcsrf.getSettings().verifyExcludes, true );
 		return actionsToExcludes
-			.filter( function( item ){
-				// If found, then don't return it
-				return !reFindNoCase( item, event.getCurrentEvent() );
-			} )
-			.len() != actionsToExcludes.len();
+			.some( function( item ){
+				return reFindNoCase( item, event.getCurrentEvent() );
+			} );
 	}
 
 	/**

--- a/test-harness/tests/specs/csrfVerifierSpec.cfc
+++ b/test-harness/tests/specs/csrfVerifierSpec.cfc
@@ -43,6 +43,19 @@ component extends="coldbox.system.testing.BaseTestCase" appMapping="/root" {
 				expect( logger.$callLog().debug[ 1 ][ 1 ] ).toInclude( "cbcsrf Verify skipped as event:" );
 			} );
 
+			it( "should not verify if the method is in the cbdebugger module", function(){
+				var logger = prepareMock( verifier.getLog() ).$( "canDebug", true ).$( "debug" );
+				event.$( "getHTTPMethod", "POST" ).$( "getCurrentEvent", "cbDebugger:main" );
+
+				verifier.preProcess(
+					event,
+					{},
+					event.getCollection(),
+					event.getPrivateCollection()
+				);
+				expect( logger.$callLog().debug[ 1 ][ 1 ] ).toInclude( "cbcsrf Verify skipped as event:" );
+			} );
+
 			it( "should not verify if the action is marked for skipping", function(){
 				var logger = prepareMock( verifier.getLog() ).$( "canDebug", true ).$( "debug" );
 				event.$( "getHTTPMethod", "POST" ).$( "getCurrentEvent", "verify.index" );


### PR DESCRIPTION
# Description

Currently when using cbcrsf with cbdebugger, if you set `enableAutoVerifier` to `true`, then you can't use the 'show request' from cbdebugger as you get TokenNotFoundException. 

This change whitelists cbdebugger requests to exclude them verification. Note that cbdebugger is always excluded even if a user sets the `verifyExcludes` module setting instead of using the default.

Note that this change uses `arraySome` which is supported in Lucee and CF2018.0.5+

## Issues

https://ortussolutions.atlassian.net/browse/BOX-140

## Type of change

- [ x ] Improvement

## Checklist

- [ x ] My code follows the style guidelines of this project [cfformat](../.cfformat.json)
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ - ] I have made corresponding changes to the documentation
- [ x ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
